### PR TITLE
[FEAT] cloudinary 연동 성공 및 이미지 뜨는거 확인

### DIFF
--- a/BlogFront/src/hooks/uploadToCloud.js
+++ b/BlogFront/src/hooks/uploadToCloud.js
@@ -1,0 +1,16 @@
+const uploadToCloudinary = async (file) => {
+  const url = `${import.meta.env.VITE_CLOUDINARY_URL}`;
+  const formData = new FormData();
+  formData.append("file", file); // 파일 데이터
+  formData.append("upload_preset", `${import.meta.env.VITE_CLOUDINARY_PRESET}`); // 업로드 프리셋
+
+  const response = await fetch(url, {
+    method: "POST",
+    body: formData,
+  });
+
+  const data = await response.json();
+  return data.secure_url; // Cloudinary에서 반환된 이미지 URL
+};
+
+export default uploadToCloudinary;

--- a/BlogFront/src/pages/Blog/BlogEdit.jsx
+++ b/BlogFront/src/pages/Blog/BlogEdit.jsx
@@ -5,6 +5,8 @@ import styled from "styled-components";
 import axios from "axios";
 import Swal from "sweetalert2";
 
+import uploadToCloudinary from "../../hooks/uploadToCloud";
+
 const BlogEdit = () => {
   const [content, setContent] = useState("");
   const [title, setTitle] = useState("");
@@ -26,6 +28,47 @@ const BlogEdit = () => {
 
   const convertContent = () => {
     return { __html: marked.parse(content) };
+  };
+
+  // const handleInput = (e) => {
+  //   const text = e.target.innerText;
+  //   setContent(text);
+
+  //   const formatted = text
+  //     .replace(/^### (.*$)/gm, `<h3>$1</h3>`) // H3
+  //     .replace(/^## (.*$)/gm, `<h2>$1</h2>`) // H2
+  //     .replace(/^# (.*$)/gm, `<h1>$1</h1>`) // H1
+  //     .replace(/\*\*(.*?)\*\*/g, `<strong>$1</strong>`) // Bold
+  //     .replace(/\*(.*?)\*/g, `<em>$1</em>`); // Italic
+
+  //   setContent(formatted);
+  //   e.target.innerHTML = formatted;
+  //   placeCaretAtEnd(e.target);
+  // };
+
+  // const placeCaretAtEnd = (el) => {
+  //   const range = document.createRange();
+  //   const sel = window.getSelection();
+  //   range.selectNodeContents(el);
+  //   range.collapse(false);
+  //   sel.removeAllRanges();
+  //   sel.addRange(range);
+  // };
+
+  const handlePaste = async (event) => {
+    const items = event.clipboardData.items;
+
+    // 클립보드에 있는 데이터 중 이미지 확인
+    for (const item of items) {
+      if (item.type.startsWith("image/")) {
+        const file = item.getAsFile();
+        const imageUrl = await uploadToCloudinary(file); // Cloudinary에 업로드
+
+        // 이미지 URL을 마크다운 형식으로 추가
+        const imageMarkdown = `\n![Image Description](${imageUrl})\n`;
+        setContent((prev) => prev + imageMarkdown);
+      }
+    }
   };
 
   const handleClick = async (e) => {
@@ -94,9 +137,10 @@ const BlogEdit = () => {
           />
         </TitleContainer>
         <TextArea
-          placeholder="Enter your Content here..."
+          placeholder="Enter your Text here..."
           value={content}
           onChange={(e) => setContent(e.target.value)}
+          onPaste={handlePaste}
         />
         <SubmitButton onClick={(e) => handleClick(e.target.value)}>
           Submit
@@ -151,7 +195,6 @@ const TextArea = styled.textarea`
   width: 95%;
   height: 100%;
   padding: 15px;
-  resize: none;
   font-size: 16px;
   border: 1px solid #ccc;
   border-radius: 5px;


### PR DESCRIPTION
이미지를 복사해서 붙여넣는 경우만 일단 고려했습니다
이미지를 파일에서 끌어와서 넣는건 아직 제가 부족해서 모르는듯 합니다 ㅜㅜ

기본 로직을 설명하면..

> 1. 이미지를 붙여넣는 순간 이벤트를 trigger
> 2. 그 붙여넣은 이미지를 그대로 cloudinary 서버에 올리고 url 을 반환
> 3. 마크다운 기법에 맞춰서 url 처리해주기

말만 들어도 굉장히 간단해요
대충 스크린샷으로 표현하자면

---
<img width="331" alt="image" src="https://github.com/user-attachments/assets/0c42bf4c-fd7f-4740-bd8b-24d6b0aa3aa3" />

이런식으로 복사 붙여넣기를 하면 url에 저장해서 옆에 띄워줍니다..
저장된거까지 보여주고 싶은데 주소가 노출되어서.. 아쉽게도

<img width="600" alt="image" src="https://github.com/user-attachments/assets/55a8ecd4-ec73-4cbd-801c-9e9c6e3a0223" />

실제로 이렇게 잘 가져오는 점을 확인할 수 있었습니당 ㅎ.ㅎ

수정해야 하는 부분은 아직 크기는 조절 안하고 넣어서 CSS를 다 뭉개버리네요
안그래도 좀 CSS 고치려했는데 잘됐네요